### PR TITLE
msm8996-common: Improve SELinux policies

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -7,6 +7,7 @@ LOCAL_MODULE       := init.cnss.sh
 LOCAL_MODULE_TAGS  := optional eng
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES    := etc/init.cnss.sh
+LOCAL_MODULE_PATH  := $(TARGET_OUT_EXECUTABLES)
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
@@ -14,6 +15,7 @@ LOCAL_MODULE       := init.panel.sh
 LOCAL_MODULE_TAGS  := optional eng
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES    := etc/init.panel.sh
+LOCAL_MODULE_PATH  := $(TARGET_OUT_EXECUTABLES)
 include $(BUILD_PREBUILT)
 
 # Common init scripts

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -519,10 +519,9 @@ service cnss-daemon /system/bin/cnss-daemon -n -l
     user system
     group system inet net_admin wifi
 
-service cnss-sh /system/bin/sh /system/etc/init.cnss.sh
+service cnss-sh /system/bin/init.cnss.sh
     class core
     user root
-    seclabel u:r:init_cnss:s0
     oneshot
 
 on property:sys.shutdown.requested=*
@@ -539,7 +538,7 @@ service qcom-sh /system/bin/sh /init.qcom.sh
     user root
     oneshot
 
-service panel-sh /system/bin/sh /system/etc/init.panel.sh
+service panel-sh /system/bin/init.panel.sh
     class core
     user root
     oneshot

--- a/sepolicy/adsprpcd.te
+++ b/sepolicy/adsprpcd.te
@@ -1,2 +1,1 @@
-allow adsprpcd dsp_file:dir r_dir_perms;
-allow adsprpcd dsp_file:file r_file_perms;
+r_dir_file(adsprpcd, dsp_file)

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -5,6 +5,7 @@
 /dev/pn548                            u:object_r:nfc_device:s0
 /dev/sysmatdrv                        u:object_r:sysmatdrv_device:s0
 
+# Sys files
 /sys/devices/soc/75ba000\.i2c/i2c-12/12-0020/input/input[0-9]+/reversed_keys    u:object_r:proc_touchpanel:s0
 /sys/devices/soc/75ba000\.i2c/i2c-12/12-004a/reversed_keys                      u:object_r:proc_touchpanel:s0
 
@@ -26,3 +27,5 @@
 
 # Binaries
 /system/bin/readmac                   u:object_r:readmac_exec:s0
+/system/bin/init\.cnss\.sh            u:object_r:init_cnss_exec:s0
+/system/bin/init\.panel\.sh           u:object_r:init_panel_exec:s0

--- a/sepolicy/init_cnss.te
+++ b/sepolicy/init_cnss.te
@@ -1,9 +1,11 @@
 type init_cnss, domain, domain_deprecated;
+type init_cnss_exec, exec_type, file_type;
 
+# Allow for transition from init domain to init_cnss
 init_daemon_domain(init_cnss)
 
 # Shell script needs to execute /system/bin/sh
-allow init_cnss shell_exec:file { entrypoint r_file_perms };
+allow init_cnss shell_exec:file rx_file_perms;
 allow init_cnss toolbox_exec:file rx_file_perms;
 
 # Allow writing to /sys/module/cnss_common/parameters/bdwlan_file
@@ -14,4 +16,5 @@ allow init_cnss sysfs_cnss_common:file w_file_perms;
 allow init_cnss persist_file:dir search;
 allow init_cnss persist_file:file r_file_perms;
 
+# Run grep
 allow init_cnss self:capability { dac_override dac_read_search };

--- a/sepolicy/init_panel.te
+++ b/sepolicy/init_panel.te
@@ -1,0 +1,12 @@
+type init_panel, domain, domain_deprecated;
+type init_panel_exec, exec_type, file_type;
+
+# Allow for transition from init domain to init_panel
+init_daemon_domain(init_panel)
+
+# Shell script needs to execute /system/bin/sh
+allow init_panel shell_exec:file rx_file_perms;
+allow init_panel toolbox_exec:file rx_file_perms;
+
+# Set panel property
+set_prop(init_panel, system_panel_prop)

--- a/sepolicy/property.te
+++ b/sepolicy/property.te
@@ -1,0 +1,1 @@
+type system_panel_prop, property_type;

--- a/sepolicy/property_contexts
+++ b/sepolicy/property_contexts
@@ -4,3 +4,4 @@ dual.camera.cs.br          u:object_r:camera_prop:s0
 ro.sys.oem.sno             u:object_r:system_radio_prop:s0
 sys.fake_bs_flag0          u:object_r:system_radio_prop:s0
 sys.fake_bs_flag1          u:object_r:system_radio_prop:s0
+sys.panel.color            u:object_r:system_panel_prop:s0

--- a/sepolicy/sensors.te
+++ b/sepolicy/sensors.te
@@ -1,0 +1,1 @@
+get_prop(sensors, system_panel_prop)


### PR DESCRIPTION
 * Move .sh scripts to /system/bin
 * Set a domain per script
 * Label panel color property
 * Switch to global macros

Change-Id: Id989128551c5a2acfbe8ae7df08ed2e2703c3040