### PR TITLE
msm8996-common: Implement QfpListener

### DIFF
--- a/qfplistener/Android.mk
+++ b/qfplistener/Android.mk
@@ -1,0 +1,13 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_SRC_FILES := $(call all-java-files-under, src)
+LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := true
+LOCAL_PACKAGE_NAME := QfpListener
+
+LOCAL_PROGUARD_ENABLED := disabled
+
+LOCAL_PRIVILEGED_MODULE := true
+LOCAL_MODULE_TAGS := optional
+include $(BUILD_PACKAGE)

--- a/qfplistener/AndroidManifest.xml
+++ b/qfplistener/AndroidManifest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2017 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          android:sharedUserId="android.uid.system"
+          package="org.lineageos.qfplistener"
+          android:versionCode="1"
+          android:versionName="1.0" >
+
+    <uses-sdk
+        android:minSdkVersion="24" />
+
+    <application
+        android:defaultToDeviceProtectedStorage="true"
+        android:directBootAware="true">
+
+        <receiver android:name=".Startup">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+    </application>
+
+</manifest>

--- a/qfplistener/src/org/lineageos/qfplistener/ScreenReceiver.java
+++ b/qfplistener/src/org/lineageos/qfplistener/ScreenReceiver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lineageos.qfplistener;
+
+import android.app.KeyguardManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.SystemProperties;
+
+public class ScreenReceiver extends BroadcastReceiver {
+
+    private KeyguardManager mKeyguardManager;
+
+    public ScreenReceiver(Context context) {
+        mKeyguardManager = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+
+        setLockscreenMode(true);
+    }
+
+    private void setLockscreenMode(boolean enabled) {
+        SystemProperties.set("sys.qfp.lockscreen", enabled ? "1" : "0");
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String action = intent.getAction();
+
+        if (action.equals(Intent.ACTION_SCREEN_OFF)) {
+            setLockscreenMode(true);
+        } else if (!mKeyguardManager.isKeyguardLocked()) {
+            setLockscreenMode(false);
+        }
+    }
+
+}

--- a/qfplistener/src/org/lineageos/qfplistener/Startup.java
+++ b/qfplistener/src/org/lineageos/qfplistener/Startup.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lineageos.qfplistener;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import org.lineageos.qfplistener.ScreenReceiver;
+
+public class Startup extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
+        intentFilter.addAction(Intent.ACTION_SCREEN_ON);
+        intentFilter.addAction(Intent.ACTION_USER_PRESENT);
+
+        context.getApplicationContext().registerReceiver(
+                new ScreenReceiver(context), intentFilter);
+    }
+
+}


### PR DESCRIPTION
* QfpListener sets sys.qfp.lockscreen property based
  on the device being in locked or unlocked state ( 1/0 ).

* That prop is supposed to prevent from disabling
  the home button while device is idling on lockscreen
  for devices using QFP sensor ( capricorn ).

Change-Id: Ie473cfc7d4127c00fd358a38ebc69ff17d57fa84