### PR TITLE
msm8996-common: Set cnss-sh user to system

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -224,6 +224,9 @@ on boot
     # Allow access for CCID command/response timeout configuration
     chown system system /sys/module/ccid_bridge/parameters/bulk_msg_timeout
 
+    # Allow access for WLAN firmware
+    chown system system /sys/module/cnss_common/parameters/bdwlan_file
+
 on fs
     wait /dev/block/bootdevice
     mount_all fstab.qcom
@@ -525,7 +528,7 @@ service cnss-daemon /system/bin/cnss-daemon -n -l
 
 service cnss-sh /system/bin/init.cnss.sh
     class core
-    user root
+    user system
     oneshot
 
 on property:sys.shutdown.requested=*

--- a/sepolicy/init_cnss.te
+++ b/sepolicy/init_cnss.te
@@ -15,6 +15,3 @@ allow init_cnss sysfs_cnss_common:file w_file_perms;
 # Allow reading files in /persist, mainly /persist/wlan_bt/ff_flag
 allow init_cnss persist_file:dir search;
 allow init_cnss persist_file:file r_file_perms;
-
-# Run grep
-allow init_cnss self:capability { dac_override dac_read_search };


### PR DESCRIPTION
* /persist/wlan_bt/ff_flag owner is system and running the script as root
  needs dac_override capability
  -> Run the script as system
     and change /sys/module/cnss_common/parameters/bdwlan_file owner accordly

Change-Id: I971c48e809ab60492520a50e03bfd9f6954d6bac