### PR TITLE
msm8996-common: Disable inline xattr feature for F2FS formatted /data

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -11,7 +11,7 @@
 /dev/block/bootdevice/by-name/cache          /cache             f2fs    nosuid,nodev,noatime,inline_xattr,flush_merge,data_flush    wait,check,formattable
 /dev/block/bootdevice/by-name/cache          /cache             ext4    nosuid,nodev,noatime,barrier=1                              wait,check,formattable
 /dev/block/bootdevice/by-name/system         /system            ext4    ro,barrier=1                                                wait
-/dev/block/bootdevice/by-name/userdata       /data              f2fs    nosuid,nodev,noatime,inline_xattr,data_flush                wait,check,encryptable=footer,formattable,length=-16384
+/dev/block/bootdevice/by-name/userdata       /data              f2fs    nosuid,nodev,noatime,data_flush                             wait,check,encryptable=footer,formattable,length=-16384
 /dev/block/bootdevice/by-name/userdata       /data              ext4    nosuid,nodev,noatime,barrier=1,noauto_da_alloc              wait,check,encryptable=footer,formattable,length=-16384
 /dev/block/bootdevice/by-name/persist        /persist           ext4    nosuid,nodev,barrier=1                                      wait
 /dev/block/bootdevice/by-name/dsp            /dsp               ext4    ro,nosuid,nodev,barrier=1,context=u:object_r:dsp_file:s0   wait


### PR DESCRIPTION
 * This is causing kernel panics since the latest F2FS updates
   (https://github.com/LineageOS/android_kernel_xiaomi_msm8996/commit/b774717c00bb)

Change-Id: I356fe89bd8927acf4ed5cbb037185f81f2e91d3e