### PR TITLE
Revert "msm8996-common: Remove unused IMS props"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -90,6 +90,8 @@ persist.loc.nlp_name=com.qualcomm.location
 ro.gps.agps_provider=1
 
 # IMS
+persist.dbg.volte_avail_ovr=1
+persist.dbg.vt_avail_ovr=1
 persist.radio.NO_STAPA=1
 persist.radio.VT_HYBRID_ENABLE=1
 


### PR DESCRIPTION
* These props aren't useless, they allow us to
  bypass CarrierConfig restrictions.

This reverts commit cf58cae575b19e1dd56d2f8008e7d2a88cf3f10c.

Change-Id: I54e1c64da552cca3b71708faba8f6a26a78e674e